### PR TITLE
Date format changed from `YYYY/MM/DD` to `YYYY-MM-DD`

### DIFF
--- a/src/graphql/resolvers/Appointment.js
+++ b/src/graphql/resolvers/Appointment.js
@@ -54,12 +54,14 @@ export default {
 			}
 		},
 		async getAppointmentsByDateRange(_, { startDate, endDate }) {
-			const start = moment(startDate).startOf('day').format('YYYY/MM/DD HH:mm');
-			const end = moment(endDate).endOf('day').format('YYYY/MM/DD HH:mm');
+			const start = moment(startDate).startOf('day').format('YYYY-MM-DD HH:mm');
+			const end = moment(endDate).endOf('day').format('YYYY-MM-DD HH:mm');
 
 			try {
 				const appointments = await Appointment.find({
 					start_date: { $gte: start, $lt: end },
+				}).sort({
+					start_date: 1,
 				});
 				if (!appointments) {
 					throw new Error('No Appointments found between this date range!', Error);
@@ -104,8 +106,8 @@ export default {
 
 			const newAppointment = new Appointment({
 				title,
-				start_date: moment(start_date).format('YYYY/MM/DD HH:mm'),
-				end_date: moment(end_date).format('YYYY/MM/DD HH:mm'),
+				start_date: moment(start_date).format('YYYY-MM-DD HH:mm'),
+				end_date: moment(end_date).format('YYYY-MM-DD HH:mm'),
 				classname,
 				description,
 				editable,
@@ -113,7 +115,7 @@ export default {
 				doctor,
 				createdBy: user._id,
 				patient,
-				createdAt: moment().format('YYYY/MM/DD HH:mm'),
+				createdAt: moment().format('YYYY-MM-DD HH:mm'),
 			});
 
 			const appointment = await newAppointment.save();
@@ -151,8 +153,8 @@ export default {
 						{ _id: appointmentId },
 						{
 							title,
-							start_date: moment(start_date).format('YYYY/MM/DD HH:mm'),
-							end_date: moment(end_date).format('YYYY/MM/DD HH:mm'),
+							start_date: moment(start_date).format('YYYY-MM-DD HH:mm'),
+							end_date: moment(end_date).format('YYYY-MM-DD HH:mm'),
 							classname,
 							description,
 							editable,
@@ -160,7 +162,7 @@ export default {
 							doctor,
 							createdBy: user._id,
 							patient,
-							updatedAt: moment().format('YYYY/MM/DD HH:mm'),
+							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }
 					);

--- a/src/graphql/resolvers/Doctor.js
+++ b/src/graphql/resolvers/Doctor.js
@@ -22,7 +22,7 @@ export default {
 						firstname,
 						lastname,
 						status,
-						createdAt: moment().format('YYYY/MM/DD HH:mm'),
+						createdAt: moment().format('YYYY-MM-DD HH:mm'),
 					});
 					await newDoctor.save();
 
@@ -47,7 +47,7 @@ export default {
 							firstname,
 							lastname,
 							status,
-							updatedAt: moment().format('YYYY/MM/DD HH:mm'),
+							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }
 					);

--- a/src/graphql/resolvers/Image.js
+++ b/src/graphql/resolvers/Image.js
@@ -31,7 +31,7 @@ export default {
 						appointment,
 						uploadedBy: user._id,
 						url,
-						createdAt: moment().format('YYYY/MM/DD HH:mm'),
+						createdAt: moment().format('YYYY-MM-DD HH:mm'),
 					});
 
 					await newImage.save();

--- a/src/graphql/resolvers/Patient.js
+++ b/src/graphql/resolvers/Patient.js
@@ -47,7 +47,7 @@ export default {
 						allergies,
 						records,
 						status,
-						createdAt: moment().format('YYYY/MM/DD HH:mm'),
+						createdAt: moment().format('YYYY-MM-DD HH:mm'),
 					});
 					await newPatient.save();
 
@@ -99,7 +99,7 @@ export default {
 							allergies,
 							records,
 							status,
-							updatedAt: moment().format('YYYY/MM/DD HH:mm'),
+							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }
 					);

--- a/src/graphql/resolvers/User.js
+++ b/src/graphql/resolvers/User.js
@@ -95,7 +95,7 @@ export default {
 				email,
 				password,
 				profilePic,
-				createdAt: moment().format('YYYY/MM/DD HH:mm'),
+				createdAt: moment().format('YYYY-MM-DD HH:mm'),
 			});
 
 			const res = await newUser.save();
@@ -120,7 +120,7 @@ export default {
 							firstname,
 							lastname,
 							email,
-							updatedAt: moment().format('YYYY/MM/DD HH:mm'),
+							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }
 					);
@@ -156,7 +156,7 @@ export default {
 							{ _id: userId },
 							{
 								password,
-								updatedAt: moment().format('YYYY/MM/DD HH:mm'),
+								updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 							},
 							{ new: true }
 						);


### PR DESCRIPTION
Date format changed from `YYYY/MM/DD` to `YYYY-MM-DD` to fix momentjs date parse errors on resolver inputs, 