### PR TITLE
Improve better code legibility in resolvers

### DIFF
--- a/src/graphql/resolvers/Appointment.js
+++ b/src/graphql/resolvers/Appointment.js
@@ -74,47 +74,25 @@ export default {
 		},
 	},
 	Mutation: {
-		async createAppointment(
-			_,
-			{
-				input: {
-					title,
-					start_date,
-					end_date,
-					classname,
-					description,
-					editable,
-					allday,
-					doctor,
-					patient,
-				},
-			},
-			context
-		) {
+		async createAppointment(_, { input }, context) {
 			const user = checkAuth(context);
 
 			///verify if the fields are empty
-			if (title.trim() === '') {
+			if (input.title.trim() === '') {
 				throw new Error('Title field must not be empty');
 			}
-			if (start_date.trim() === '') {
+			if (input.start_date.trim() === '') {
 				throw new Error('Start date field must not be empty');
 			}
-			if (end_date.trim() === '') {
+			if (input.end_date.trim() === '') {
 				throw new Error('End date field must not be empty');
 			}
 
 			const newAppointment = new Appointment({
-				title,
-				start_date: moment(start_date).format('YYYY-MM-DD HH:mm'),
-				end_date: moment(end_date).format('YYYY-MM-DD HH:mm'),
-				classname,
-				description,
-				editable,
-				allday,
-				doctor,
+				...input,
+				start_date: moment(input.start_date).format('YYYY-MM-DD HH:mm'),
+				end_date: moment(input.end_date).format('YYYY-MM-DD HH:mm'),
 				createdBy: user._id,
-				patient,
 				createdAt: moment().format('YYYY-MM-DD HH:mm'),
 			});
 
@@ -122,24 +100,7 @@ export default {
 
 			return appointment;
 		},
-		async updateAppointment(
-			_,
-			{
-				appointmentId,
-				input: {
-					title,
-					start_date,
-					end_date,
-					classname,
-					description,
-					editable,
-					allday,
-					doctor,
-					patient,
-				},
-			},
-			context
-		) {
+		async updateAppointment(_, { appointmentId, input }, context) {
 			const user = checkAuth(context);
 			const appointment = await Appointment.findOne(
 				{ _id: appointmentId },
@@ -152,16 +113,9 @@ export default {
 					const updatedAppointment = await Appointment.findOneAndUpdate(
 						{ _id: appointmentId },
 						{
-							title,
-							start_date: moment(start_date).format('YYYY-MM-DD HH:mm'),
-							end_date: moment(end_date).format('YYYY-MM-DD HH:mm'),
-							classname,
-							description,
-							editable,
-							allday,
-							doctor,
-							createdBy: user._id,
-							patient,
+							...input,
+							start_date: moment(input.start_date).format('YYYY-MM-DD HH:mm'),
+							end_date: moment(input.end_date).format('YYYY-MM-DD HH:mm'),
 							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }

--- a/src/graphql/resolvers/Doctor.js
+++ b/src/graphql/resolvers/Doctor.js
@@ -13,15 +13,13 @@ export default {
 		},
 	},
 	Mutation: {
-		async createDoctor(_, { input: { firstname, lastname, status } }, context) {
+		async createDoctor(_, { input }, context) {
 			const user = checkAuth(context);
 
 			try {
 				if (user) {
 					const newDoctor = new Doctor({
-						firstname,
-						lastname,
-						status,
+						...input,
 						createdAt: moment().format('YYYY-MM-DD HH:mm'),
 					});
 					await newDoctor.save();
@@ -36,7 +34,7 @@ export default {
 				throw new Error(err);
 			}
 		},
-		async updateDoctor(_, { doctorId, input: { firstname, lastname, status } }, context) {
+		async updateDoctor(_, { doctorId, input }, context) {
 			const user = checkAuth(context);
 
 			try {
@@ -44,9 +42,7 @@ export default {
 					return await Doctor.findOneAndUpdate(
 						{ _id: doctorId },
 						{
-							firstname,
-							lastname,
-							status,
+							...input,
 							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }

--- a/src/graphql/resolvers/Image.js
+++ b/src/graphql/resolvers/Image.js
@@ -19,18 +19,14 @@ export default {
 		},
 	},
 	Mutation: {
-		async uploadImage(_, { input: { name, size, pacient, appointment, url } }, context) {
+		async uploadImage(_, { input }, context) {
 			const user = checkAuth(context);
 
 			try {
 				if (user) {
 					const newImage = new Image({
-						name,
-						size,
-						pacient,
-						appointment,
+						...input,
 						uploadedBy: user._id,
-						url,
 						createdAt: moment().format('YYYY-MM-DD HH:mm'),
 					});
 

--- a/src/graphql/resolvers/Patient.js
+++ b/src/graphql/resolvers/Patient.js
@@ -13,40 +13,12 @@ export default {
 		},
 	},
 	Mutation: {
-		async createPatient(
-			_,
-			{
-				input: {
-					firstname,
-					lastname,
-					birthDate,
-					idDocument,
-					phoneNumber,
-					email,
-					address,
-					referedBy,
-					allergies,
-					records,
-					status,
-				},
-			},
-			context
-		) {
+		async createPatient(_, { input }, context) {
 			try {
 				const user = checkAuth(context);
 				if (user) {
 					const newPatient = new Patient({
-						firstname,
-						lastname,
-						birthDate,
-						idDocument,
-						phoneNumber,
-						email,
-						address,
-						referedBy,
-						allergies,
-						records,
-						status,
+						...input,
 						createdAt: moment().format('YYYY-MM-DD HH:mm'),
 					});
 					await newPatient.save();
@@ -61,26 +33,7 @@ export default {
 				throw new Error(err);
 			}
 		},
-		async updatePatient(
-			_,
-			{
-				patientId,
-				input: {
-					firstname,
-					lastname,
-					birthDate,
-					idDocument,
-					phoneNumber,
-					email,
-					address,
-					referedBy,
-					allergies,
-					records,
-					status,
-				},
-			},
-			context
-		) {
+		async updatePatient(_, { patientId, input }, context) {
 			const user = checkAuth(context);
 
 			try {
@@ -88,17 +41,7 @@ export default {
 					return await Patient.findByIdAndUpdate(
 						patientId,
 						{
-							firstname,
-							lastname,
-							birthDate,
-							idDocument,
-							phoneNumber,
-							email,
-							address,
-							referedBy,
-							allergies,
-							records,
-							status,
+							...input,
 							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }

--- a/src/graphql/resolvers/User.js
+++ b/src/graphql/resolvers/User.js
@@ -108,7 +108,7 @@ export default {
 				token,
 			};
 		},
-		async updateUserInfo(_, { userId, input: { firstname, lastname, email } }, context) {
+		async updateUserInfo(_, { userId, input }, context) {
 			const user = checkAuth(context);
 			const dbUser = await User.findOne({ _id: userId });
 
@@ -117,9 +117,7 @@ export default {
 					const res = await User.findOneAndUpdate(
 						{ _id: userId },
 						{
-							firstname,
-							lastname,
-							email,
+							...input,
 							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }


### PR DESCRIPTION
use `...input` instead of input destructuring like this: `{ input: { firstname, lastname, birthDate, etc }` and give the mutable fields like `createdAt` and `updatedAt` separately once that fields are filled correctly.