### PR TITLE
changed some field names in models, resolvers and schemas.

### DIFF
--- a/src/graphql/resolvers/Appointment.js
+++ b/src/graphql/resolvers/Appointment.js
@@ -28,7 +28,7 @@ export default {
 		async getAppointmentsByDoctor(_, { doctorId }) {
 			try {
 				const appointments = await Appointment.find({ doctor: doctorId }).sort({
-					start_date: -1,
+					start: -1,
 				});
 				if (!appointments) {
 					throw new Error('Appointments of this doctor not found!', Error);
@@ -59,9 +59,9 @@ export default {
 
 			try {
 				const appointments = await Appointment.find({
-					start_date: { $gte: start, $lt: end },
+					start: { $gte: start, $lt: end },
 				}).sort({
-					start_date: 1,
+					start: 1,
 				});
 				if (!appointments) {
 					throw new Error('No Appointments found between this date range!', Error);
@@ -81,17 +81,17 @@ export default {
 			if (input.title.trim() === '') {
 				throw new Error('Title field must not be empty');
 			}
-			if (input.start_date.trim() === '') {
+			if (input.start.trim() === '') {
 				throw new Error('Start date field must not be empty');
 			}
-			if (input.end_date.trim() === '') {
+			if (input.end.trim() === '') {
 				throw new Error('End date field must not be empty');
 			}
 
 			const newAppointment = new Appointment({
 				...input,
-				start_date: moment(input.start_date).format('YYYY-MM-DD HH:mm'),
-				end_date: moment(input.end_date).format('YYYY-MM-DD HH:mm'),
+				start: moment(input.start).format('YYYY-MM-DD HH:mm'),
+				end: moment(input.end).format('YYYY-MM-DD HH:mm'),
 				createdBy: user._id,
 				createdAt: moment().format('YYYY-MM-DD HH:mm'),
 			});
@@ -114,8 +114,8 @@ export default {
 						{ _id: appointmentId },
 						{
 							...input,
-							start_date: moment(input.start_date).format('YYYY-MM-DD HH:mm'),
-							end_date: moment(input.end_date).format('YYYY-MM-DD HH:mm'),
+							start: moment(input.start).format('YYYY-MM-DD HH:mm'),
+							end: moment(input.end).format('YYYY-MM-DD HH:mm'),
 							updatedAt: moment().format('YYYY-MM-DD HH:mm'),
 						},
 						{ new: true }

--- a/src/graphql/schemas/Appointment.js
+++ b/src/graphql/schemas/Appointment.js
@@ -2,14 +2,14 @@ import { gql } from 'apollo-server-express';
 
 export default gql`
 	type Appointment {
-		_id: ID!
+		id: ID!
 		title: String!
-		start_date: String!
-		end_date: String!
-		classname: String
+		start: String!
+		end: String!
+		className: String
 		description: String
 		editable: Boolean
-		allday: Boolean
+		allDay: Boolean
 		doctor: Doctor
 		createdBy: User!
 		patient: Patient
@@ -27,12 +27,12 @@ export default gql`
 
 	input appointmentInput {
 		title: String!
-		start_date: String!
-		end_date: String!
-		classname: String
+		start: String!
+		end: String!
+		className: String
 		description: String
 		editable: Boolean
-		allday: Boolean
+		allDay: Boolean
 		doctor: ID
 		patient: ID
 	}

--- a/src/models/Appointment.js
+++ b/src/models/Appointment.js
@@ -2,9 +2,9 @@ import { Schema, model } from 'mongoose';
 
 const appointmentSchema = new Schema({
 	title: String,
-	start_date: String,
-	end_date: String,
-	classname: {
+	start: String,
+	end: String,
+	className: {
 		type: String,
 		default: 'Pendiente',
 	},
@@ -16,7 +16,7 @@ const appointmentSchema = new Schema({
 		type: Boolean,
 		default: true,
 	},
-	allday: {
+	allDay: {
 		type: Boolean,
 		default: false,
 	},
@@ -38,6 +38,14 @@ const appointmentSchema = new Schema({
 	},
 	createdAt: String,
 	updatedAt: String,
+});
+
+appointmentSchema.set('toJSON', {
+	virtuals: true,
+	versionKey: false,
+	transform: function (doc, ret) {
+		delete ret._id;
+	},
 });
 
 appointmentSchema.plugin(require('mongoose-autopopulate'));


### PR DESCRIPTION
Changed names in mongoose models, graphql schemas and resolvers to fix an `event parse error` on the frontend client, `classname` to `className`, `start_date` to `start`, `end_date` to `end`, `allday` to `allDay` and added a method in `Appointment` model to receive `id` instead of `_id` and give the option to add the unique identifier to the events on fullcalendar.